### PR TITLE
Fix #32: don't push to dockerhub for PRs and non-master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ after_success:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
   # release :latest and :centos-latest
-  - make image-publish-all
+  - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then make image-publish-all; fi
 
   # release x.y.z or x.y.z-centos if there is a release
   - ./.travis/.travis.release.images.sh


### PR DESCRIPTION
no need to handle this for `./.travis/.travis.release.images.sh` because the check is already in the script