### PR TITLE
adjusting the test outputs to work against the new minikube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,6 @@ jobs:
         - ./.travis/.travis.prepare.minikube.sh
         - ./.travis/.travis.test-oc-and-k8s.sh
 
-#    - stage:
-#      env: BIN=kubectl VERSION=v1.11.0 MINIKUBE_VERSION=v0.28.1
-#      script:
-#        - make build
-#        - ./.travis/.travis.prepare.minikube.sh
-#        - ./.travis/.travis.test-oc-and-k8s.sh
-
     - stage: deploy
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
minikubes newer than `0.25.2` can't start properly on Travis CI, but the test suite can be run locally. New k8s has different output when creating objects hence the change in the "grepping" reg. expression.