### PR TITLE
No vertex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,12 @@
             <artifactId>kubernetes-client</artifactId>
 	        <version>${fabric8.kubernetes-client.version}</version>
         </dependency>
-        <dependency>
+<!--        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-client</artifactId>
 	        <version>${fabric8.kubernetes-client.version}</version>
         </dependency>
+-->
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <fabric8.kubernetes-model.version>3.0.1</fabric8.kubernetes-model.version>
         <fabric8.zjsonpatch.version>0.3.0</fabric8.zjsonpatch.version>
         <snakeyaml.version>1.21</snakeyaml.version>
-        <vertx.version>3.5.3</vertx.version>
         <slf4j.version>1.7.25</slf4j.version>
         <junit.version>4.12</junit.version>
     </properties>
@@ -69,11 +68,6 @@
           <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
           <version>${snakeyaml.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-core</artifactId>
-	        <version>${vertx.version}</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/src/main/java/io/radanalytics/operator/Entrypoint.java
+++ b/src/main/java/io/radanalytics/operator/Entrypoint.java
@@ -3,23 +3,25 @@ package io.radanalytics.operator;
 import com.jcabi.manifests.Manifests;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.radanalytics.operator.app.AppOperator;
 import io.radanalytics.operator.cluster.ClusterOperator;
 import io.radanalytics.operator.common.AbstractOperator;
 import io.radanalytics.operator.common.EntityInfo;
 import io.radanalytics.operator.common.OperatorConfig;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
+import okhttp3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import static io.radanalytics.operator.common.AnsiColors.*;
@@ -28,28 +30,28 @@ public class Entrypoint {
 
     private static final Logger log = LoggerFactory.getLogger(Entrypoint.class.getName());
 
+    public static ExecutorService EXECUTORS = Executors.newFixedThreadPool(10);
+
     public static void main(String[] args) {
         log.info("Starting..");
         OperatorConfig config = OperatorConfig.fromMap(System.getenv());
-        Vertx vertx = Vertx.vertx();
         KubernetesClient client = new DefaultKubernetesClient();
-
-        isOnOpenShift(vertx, client).setHandler(os -> {
-            if (os.succeeded()) {
-                run(vertx, client, os.result().booleanValue(), config).setHandler(ar -> {
-                    if (ar.failed()) {
-                        log.error("Unable to start operator for 1 or more namespace", ar.cause());
-                        System.exit(1);
-                    }
-                });
-            } else {
-                log.error("Failed to distinguish between Kubernetes and OpenShift", os.cause());
-                System.exit(1);
-            }
+        boolean isOpenshift = false;
+        try {
+            isOpenshift = isOnOpenShift(client);
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.error("Failed to distinguish between Kubernetes and OpenShift", e.getCause());
+            log.warn("Let's assume we are on K8s");
+        }
+        run(client, isOpenshift, config).exceptionally(ex -> {
+            log.error("Unable to start operator for 1 or more namespace", ex);
+            System.exit(1);
+            return null;
         });
     }
 
-    private static CompositeFuture run(Vertx vertx, KubernetesClient client, boolean isOpenShift, OperatorConfig config) {
+    private static CompletableFuture<Void> run(KubernetesClient client, boolean isOpenShift, OperatorConfig config) {
         printInfo();
 
         if (isOpenShift) {
@@ -58,76 +60,69 @@ public class Entrypoint {
             log.info("Kubernetes environment detected.");
         }
 
-        List<Future> futures = new ArrayList<>();
+        List<CompletableFuture> futures = new ArrayList<>();
         if (null == config.getNamespaces()) { // get the current namespace
             String namespace = client.getNamespace();
-            Future future = runForNamespace(vertx, client, isOpenShift, namespace);
+            CompletableFuture future = runForNamespace(client, isOpenShift, namespace);
             futures.add(future);
         } else {
             for (String namespace : config.getNamespaces()) {
-                Future future = runForNamespace(vertx, client, isOpenShift, namespace);
+                CompletableFuture future = runForNamespace(client, isOpenShift, namespace);
                 futures.add(future);
             }
         }
-        return CompositeFuture.join(futures);
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[]{}));
     }
 
-    private static Future runForNamespace(Vertx vertx, KubernetesClient client, boolean isOpenShift, String namespace) {
+    private static CompletableFuture<Void> runForNamespace(KubernetesClient client, boolean isOpenShift, String namespace) {
 
         ClusterOperator clusterOperator = new ClusterOperator(namespace, isOpenShift, client);
         AppOperator appOperator = new AppOperator(namespace, isOpenShift, client);
 
         List<Future> futures = new ArrayList<>();
         Stream.of(clusterOperator, appOperator).forEach(operator -> {
-            Future<String> future = Future.future();
+            CompletableFuture<Watch> future = operator.start().thenApply(res -> {
+                log.info("{} started in namespace {}", operator.getName(), namespace);
+                return res;
+            }).exceptionally(e -> {
+                log.error("{} in namespace {} failed to start", operator.getName(), namespace, e.getCause());
+                System.exit(1);
+                return null;
+            });
             futures.add(future);
-            vertx.deployVerticle(operator,
-                    res -> {
-                        if (res.succeeded()) {
-                            log.info("{} verticle started in namespace {}", operator.getName(), namespace);
-                        } else {
-                            log.error("{} verticle in namespace {} failed to start", operator.getName(), namespace, res.cause());
-                            System.exit(1);
-                        }
-                        future.completer().handle(res);
-                    });
         });
-        return CompositeFuture.join(futures);
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[]{}));
     }
 
-    private static Future<Boolean> isOnOpenShift(Vertx vertx, KubernetesClient client)  {
+    private static boolean isOnOpenShift(KubernetesClient client) throws IOException {
         URL kubernetesApi = client.getMasterUrl();
-        Future<Boolean> fut = Future.future();
 
-        HttpClientOptions httpClientOptions = new HttpClientOptions();
-        httpClientOptions.setDefaultHost(kubernetesApi.getHost());
+        HttpUrl.Builder urlBuilder = new HttpUrl.Builder();
+        urlBuilder.host(kubernetesApi.getHost());
 
         if (kubernetesApi.getPort() == -1) {
-            httpClientOptions.setDefaultPort(kubernetesApi.getDefaultPort());
+            urlBuilder.port(kubernetesApi.getDefaultPort());
         } else {
-            httpClientOptions.setDefaultPort(kubernetesApi.getPort());
+            urlBuilder.port(kubernetesApi.getPort());
         }
 
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
         if (kubernetesApi.getProtocol().equals("https")) {
-            httpClientOptions.setSsl(true);
-            httpClientOptions.setTrustAll(true);
+            urlBuilder.scheme("https");
+            httpClientBuilder.hostnameVerifier((hostname, session) -> true);
         }
+        urlBuilder.addPathSegment("/oapi");
 
-        HttpClient httpClient = vertx.createHttpClient(httpClientOptions);
-
-        httpClient.getNow("/oapi", res -> {
-            if (res.statusCode() == 200) {
-                log.debug("{} returned {}. We are on OpenShift.", res.request().absoluteURI(), res.statusCode());
-                // We should be on OpenShift based on the /oapi result. We can now safely try isAdaptable() to be 100% sure.
-                Boolean isOpenShift = Boolean.TRUE.equals(client.isAdaptable(OpenShiftClient.class));
-                fut.complete(isOpenShift);
-            } else {
-                log.debug("{} returned {}. We are not on OpenShift.", res.request().absoluteURI(), res.statusCode());
-                fut.complete(Boolean.FALSE);
-            }
-        });
-
-        return fut;
+        OkHttpClient httpClient = httpClientBuilder.build();
+        HttpUrl url = urlBuilder.build();
+        Response response = httpClient.newCall(new Request.Builder().url(url).build()).execute();
+        boolean success = response.isSuccessful();
+        if (success) {
+            log.debug("{} returned {}. We are on OpenShift.", url, response.code());
+        } else {
+            log.debug("{} returned {}. We are not on OpenShift.", url, response.code());
+        }
+        return success;
     }
 
     private static void printInfo() {

--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -10,19 +10,17 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.Watchable;
-import io.vertx.core.AbstractVerticle;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import io.radanalytics.operator.Entrypoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static io.radanalytics.operator.common.AnsiColors.ANSI_G;
 import static io.radanalytics.operator.common.AnsiColors.ANSI_RESET;
 
-public abstract class AbstractOperator<T extends EntityInfo> extends AbstractVerticle {
+public abstract class AbstractOperator<T extends EntityInfo> {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractOperator.class.getName());
 
@@ -62,106 +60,99 @@ public abstract class AbstractOperator<T extends EntityInfo> extends AbstractVer
         return operatorName;
     }
 
-    @Override
-    public void start(Future<Void> start) {
+    public CompletableFuture<Watch> start() {
         log.info("Starting {} for namespace {}", operatorName, namespace);
 
-        createConfigMapWatch(res -> {
-            if (res.succeeded()) {
-                configMapWatch = res.result();
+        CompletableFuture<Watch> future = createConfigMapWatch();
+        future.thenApply(res -> {
+                this.configMapWatch = res;
                 log.info("{} running for namespace {}", operatorName, namespace);
-
-                start.complete();
-            } else {
-                log.error("{} startup failed for namespace {}", operatorName, namespace, res.cause());
-                start.fail(operatorName + " startup failed for namespace {}" + namespace);
-            }
+                return res;
+        }).exceptionally(e -> {
+            log.error("{} startup failed for namespace {}", operatorName, namespace, e.getCause());
+            return null;
         });
+        return future;
     }
 
-    @Override
-    public void stop(Future<Void> stop) {
+    public void stop() {
         log.info("Stopping {} for namespace {}", operatorName, namespace);
         configMapWatch.close();
         client.close();
-        stop.complete();
     }
 
-    private void createConfigMapWatch(Handler<AsyncResult<Watch>> handler) {
-        getVertx().executeBlocking(
-                future -> {
-                    MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> aux = client.configMaps();
-                    Watchable<Watch, Watcher<ConfigMap>> watchable = "*".equals(namespace) ? aux.inAnyNamespace().withLabels(selector) : aux.inNamespace(namespace).withLabels(selector);
-                    Watch watch = watchable.watch(new Watcher<ConfigMap>() {
-                        @Override
-                        public void eventReceived(Action action, ConfigMap cm) {
-                            if (isSupported(cm)) {
-                                log.info("ConfigMap \n{}\n in namespace {} was {}", cm, namespace, action);
-                                T entity = convert(cm);
-                                if (entity == null) {
-                                    log.error("something went wrong, unable to parse {} definition", entityName);
-                                }
-                                String name = entity.getName();
-                                switch (action) {
-                                    case ADDED:
-                                        log.info("{}creating{} {}:  \n{}\n", ANSI_G, ANSI_RESET, entityName, name);
-                                        onAdd(entity, isOpenshift);
-                                        log.info("{} {} has been {}created{}", entityName, name, ANSI_G, ANSI_RESET);
-                                        break;
-                                    case DELETED:
-                                        log.info("{}deleting{} {}:  \n{}\n", ANSI_G, ANSI_RESET, entityName, name);
-                                        onDelete(entity, isOpenshift);
-                                        log.info("{} {} has been {}deleted{}", entityName, name, ANSI_G, ANSI_RESET);
-                                        break;
-                                    case MODIFIED:
-                                        log.info("{}modifying{} {}:  \n{}\n", ANSI_G, ANSI_RESET, entityName, name);
-                                        onModify(entity, isOpenshift);
-                                        log.info("{} {} has been {}modified{}", entityName, name, ANSI_G, ANSI_RESET);
-                                        break;
-                                    case ERROR:
-                                        log.error("Failed ConfigMap {} in namespace{} ", cm, namespace);
-                                        break;
-                                    default:
-                                        log.error("Unknown action: {} in namespace {}", action, namespace);
-                                }
-                            } else {
-                                log.error("Unknown CM kind: {}", cm.toString());
-                            }
+    private CompletableFuture<Watch> createConfigMapWatch() {
+        CompletableFuture<Watch> cf = CompletableFuture.supplyAsync(() -> {
+            MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> aux = client.configMaps();
+            Watchable<Watch, Watcher<ConfigMap>> watchable = "*".equals(namespace) ? aux.inAnyNamespace().withLabels(selector) : aux.inNamespace(namespace).withLabels(selector);
+            Watch watch = watchable.watch(new Watcher<ConfigMap>() {
+                @Override
+                public void eventReceived(Action action, ConfigMap cm) {
+                    if (isSupported(cm)) {
+                        log.info("ConfigMap \n{}\n in namespace {} was {}", cm, namespace, action);
+                        T entity = convert(cm);
+                        if (entity == null) {
+                            log.error("something went wrong, unable to parse {} definition", entityName);
                         }
-
-                        @Override
-                        public void onClose(KubernetesClientException e) {
-                            if (e != null) {
-                                log.error("Watcher closed with exception in namespace {}", namespace, e);
-                                recreateConfigMapWatch();
-                            } else {
-                                log.info("Watcher closed in namespace {}", namespace);
-                            }
+                        String name = entity.getName();
+                        switch (action) {
+                            case ADDED:
+                                log.info("{}creating{} {}:  \n{}\n", ANSI_G, ANSI_RESET, entityName, name);
+                                onAdd(entity, isOpenshift);
+                                log.info("{} {} has been {}created{}", entityName, name, ANSI_G, ANSI_RESET);
+                                break;
+                            case DELETED:
+                                log.info("{}deleting{} {}:  \n{}\n", ANSI_G, ANSI_RESET, entityName, name);
+                                onDelete(entity, isOpenshift);
+                                log.info("{} {} has been {}deleted{}", entityName, name, ANSI_G, ANSI_RESET);
+                                break;
+                            case MODIFIED:
+                                log.info("{}modifying{} {}:  \n{}\n", ANSI_G, ANSI_RESET, entityName, name);
+                                onModify(entity, isOpenshift);
+                                log.info("{} {} has been {}modified{}", entityName, name, ANSI_G, ANSI_RESET);
+                                break;
+                            case ERROR:
+                                log.error("Failed ConfigMap {} in namespace{} ", cm, namespace);
+                                break;
+                            default:
+                                log.error("Unknown action: {} in namespace {}", action, namespace);
                         }
-                    });
-                    future.complete(watch);
-                }, res -> {
-                    if (res.succeeded()) {
-                        log.info("ConfigMap watcher running for labels {}", selector);
-                        handler.handle(Future.succeededFuture((Watch) res.result()));
                     } else {
-                        log.info("ConfigMap watcher failed to start", res.cause());
-                        handler.handle(Future.failedFuture("ConfigMap watcher failed to start"));
+                        log.error("Unknown CM kind: {}", cm.toString());
                     }
                 }
-        );
+
+                @Override
+                public void onClose(KubernetesClientException e) {
+                    if (e != null) {
+                        log.error("Watcher closed with exception in namespace {}", namespace, e);
+                        recreateConfigMapWatch();
+                    } else {
+                        log.info("Watcher closed in namespace {}", namespace);
+                    }
+                }
+            });
+            return watch;
+        }, Entrypoint.EXECUTORS);
+        cf.thenApply(w -> {
+            log.info("ConfigMap watcher running for labels {}", selector);
+            return w;
+        }).exceptionally(e -> {
+            log.error("ConfigMap watcher failed to start", e.getCause());
+            return null;
+        });
+        return cf;
     }
 
     private void recreateConfigMapWatch() {
-        createConfigMapWatch(res -> {
-            if (res.succeeded()) {
-                log.info("ConfigMap watch recreated in namespace {}", namespace);
-                configMapWatch = res.result();
-            } else {
-                log.error("Failed to recreate ConfigMap watch in namespace {}", namespace);
-                // We failed to recreate the Watch. We cannot continue without it. Lets close Vert.x and exit.
-                vertx.close();
-            }
+        CompletableFuture<Watch> configMapWatch = createConfigMapWatch();
+        configMapWatch.thenApply(res -> {
+            log.info("ConfigMap watch recreated in namespace {}", namespace);
+            this.configMapWatch = res;
+            return res;
+        }).exceptionally(e -> {
+            log.error("Failed to recreate ConfigMap watch in namespace {}", namespace);
+            return null;
         });
     }
 


### PR DESCRIPTION
this is pre-requirements for the Graal vm native image (https://github.com/Jiri-Kremser/spark-operator/issues/9)

using `CompletableFutures` instead of `Futures` from vert.x and deploying the watchers as normal threads using [`ExecutorService`](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html)

Openshift client is also not needed, because we use only Kubernetes native features.

This PR should decrease the image size.